### PR TITLE
Add client_secret for service accounts

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -74,6 +74,7 @@ impl KeycloakAdminToken {
                 "username": username,
                 "password": password,
                 "client_id": client_id,
+                "client_secret": password,
                 "grant_type": grant_type
             }))
             .send()


### PR DESCRIPTION
Using Service Accounts requires passing the client_secret to be passed. Without client secret authentication fails, normal authentication still works as expected.