### PR TITLE
Make KeycloakAdmin clonable

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 
 mod rest;
 
+#[derive(Clone)]
 pub struct KeycloakAdmin<TS: KeycloakTokenSupplier = KeycloakAdminToken> {
     url: String,
     client: reqwest::Client,

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -18,7 +18,7 @@ pub trait KeycloakTokenSupplier {
     async fn get(&self, url: &str) -> Result<String, KeycloakError>;
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct KeycloakAdminToken {
     access_token: String,
     expires_in: usize,


### PR DESCRIPTION
In order to allow KeycloakAdmin to be usable in Tokio spawned task, it could be useful to make `KeycloakAdmin` Clonable.