### PR TITLE
For the use of a reference instead of an owned copy of the reqwest::C…

### DIFF
--- a/examples/adduser.rs
+++ b/examples/adduser.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!("{:?}", admin_token);
 
-    let admin = KeycloakAdmin::new(&url, admin_token, client);
+    let admin = KeycloakAdmin::new(&url, admin_token, &client);
 
     admin
         .post(RealmRepresentation {

--- a/src/rest/generated_rest.rs
+++ b/src/rest/generated_rest.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use super::*;
 
-impl<TS: KeycloakTokenSupplier> KeycloakAdmin<TS> {
+impl<'a, TS: KeycloakTokenSupplier> KeycloakAdmin<'a, TS> {
     /// Clear any user login failures for all users   This can release temporary disabled users
     ///
     /// Parameters:

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -6,9 +6,9 @@ use serde_json::json;
 
 mod generated_rest;
 
-pub struct KeycloakAdmin<TS: KeycloakTokenSupplier = KeycloakAdminToken> {
+pub struct KeycloakAdmin<'a, TS: KeycloakTokenSupplier = KeycloakAdminToken> {
     url: String,
-    client: reqwest::Client,
+    client: &'a reqwest::Client,
     token_supplier: TS,
 }
 
@@ -164,8 +164,8 @@ async fn error_check(response: reqwest::Response) -> Result<reqwest::Response, K
     Ok(response)
 }
 
-impl<TS: KeycloakTokenSupplier> KeycloakAdmin<TS> {
-    pub fn new(url: &str, token_supplier: TS, client: reqwest::Client) -> Self {
+impl<'a, TS: KeycloakTokenSupplier> KeycloakAdmin<'a, TS> {
+    pub fn new(url: &str, token_supplier: TS, client: &'a reqwest::Client) -> Self {
         Self {
             url: url.into(),
             client,


### PR DESCRIPTION
…lient.

This allows us to share the Client connection across multiple instances of the AdminClient (i.e. for different users).