### PR TITLE
Allow release script to do even more work

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,11 @@ If we have `x.y.z` version of `keycloak`, our package version would be `x.y.(z *
 fix version to official `x.y.z` version.
 
 Example: official version `13.0.1` is `13.0.100` for crate version. `13.0.102` means keycloak version `13.0.1` and minor fix version `2`.
+
+## Update
+
+To update current version use provided [update.ts](./update.ts) `deno` script:
+
+```sh
+deno run --allow-env=KEYCLOAK_RUST_VERSION,KEYCLOAK_VERSION,KEYCLOAK_RUST_MAJOR_VERSION --allow-read=Cargo.toml --allow-write=Cargo.toml,docs/rest-api.html,src/types.rs,src/rest/generated_rest.rs --allow-net=keycloak.org,www.keycloak.org --allow-run=cargo,gh,git update.ts
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,15 @@ If we have `x.y.z` version of `keycloak`, our package version would be `x.y.(z *
 fix version to official `x.y.z` version.
 
 Example: official version `13.0.1` is `13.0.100` for crate version. `13.0.102` means keycloak version `13.0.1` and minor fix version `2`.
+
+## Update
+
+To update current version use provided [update.ts](./update.ts) `deno` script:
+
+```sh
+deno run --allow-env=KEYCLOAK_RUST_VERSION,KEYCLOAK_VERSION,KEYCLOAK_RUST_MAJOR_VERSION --allow-read=Cargo.toml --allow-write=Cargo.toml,docs/rest-api.html,src/types.rs,src/rest/generated_rest.rs --allow-net=keycloak.org,www.keycloak.org --allow-run=cargo,gh,git update.ts
+```
+
 */
 
 pub mod types;

--- a/templates/README.md
+++ b/templates/README.md
@@ -29,3 +29,11 @@ If we have `x.y.z` version of `keycloak`, our package version would be `x.y.(z *
 fix version to official `x.y.z` version.
 
 Example: official version `13.0.1` is `13.0.100` for crate version. `13.0.102` means keycloak version `13.0.1` and minor fix version `2`.
+
+## Update
+
+To update current version use provided [update.ts](./update.ts) `deno` script:
+
+```sh
+deno run --allow-read=Cargo.toml --allow-write=Cargo.toml --allow-net=keycloak.org,www.keycloak.org --allow-run=gh,git update.ts
+```

--- a/templates/README.md
+++ b/templates/README.md
@@ -35,5 +35,5 @@ Example: official version `13.0.1` is `13.0.100` for crate version. `13.0.102` m
 To update current version use provided [update.ts](./update.ts) `deno` script:
 
 ```sh
-deno run --allow-read=Cargo.toml --allow-write=Cargo.toml --allow-net=keycloak.org,www.keycloak.org --allow-run=gh,git update.ts
+deno run --allow-read=Cargo.toml --allow-write=Cargo.toml --allow-net=keycloak.org,www.keycloak.org --allow-run=cargo,gh,git update.ts
 ```

--- a/templates/README.md
+++ b/templates/README.md
@@ -35,5 +35,5 @@ Example: official version `13.0.1` is `13.0.100` for crate version. `13.0.102` m
 To update current version use provided [update.ts](./update.ts) `deno` script:
 
 ```sh
-deno run --allow-read=Cargo.toml --allow-write=Cargo.toml --allow-net=keycloak.org,www.keycloak.org --allow-run=cargo,gh,git update.ts
+deno run --allow-env=KEYCLOAK_RUST_VERSION,KEYCLOAK_VERSION,KEYCLOAK_RUST_MAJOR_VERSION --allow-read=Cargo.toml --allow-write=Cargo.toml,docs/rest-api.html,src/types.rs,src/rest/generated_rest.rs --allow-net=keycloak.org,www.keycloak.org --allow-run=cargo,gh,git update.ts
 ```

--- a/update.sh
+++ b/update.sh
@@ -2,10 +2,43 @@
 
 set -e
 
-KEYCLOAK_RUST_VERSION=`grep "version = " Cargo.toml | head -n1 | cut -d"\"" -f 2`
-KEYCLOAK_RUST_MAJOR_VERSION=`echo ${KEYCLOAK_RUST_VERSION} | cut -f 1,2 -d"."`
-KEYCLOAK_VERSION=`echo ${KEYCLOAK_RUST_MAJOR_VERSION}.$(($(echo ${KEYCLOAK_RUST_VERSION} | cut -f 3 -d".") / 100))`
-GITHUB_ISSUE=`git branch --show-current | grep -oh "^\d*"`
+LAST_KEYCLOAK_VERSION=$(curl https://www.keycloak.org/ --no-progress-meter -o - | grep "Latest release" | xargs | cut -f3 -d" ")
+KEYCLOAK_RUST_VERSION=$(grep "version = " Cargo.toml | head -n1 | cut -d"\"" -f 2)
+KEYCLOAK_RUST_MAJOR_VERSION=$(echo ${KEYCLOAK_RUST_VERSION} | cut -f 1,2 -d".")
+KEYCLOAK_VERSION=$(echo ${KEYCLOAK_RUST_MAJOR_VERSION}.$(($(echo ${KEYCLOAK_RUST_VERSION} | cut -f 3 -d".") / 100)))
+
+function get_milestone
+{
+  milestone=$1
+  if [ -z "${milestone}" ]; then
+    echo "get_milestone: no parameter given, provide milestone!"
+    exit 1
+  fi
+  echo "checking if requested milestone (${milestone}) exists"
+  output=`gh api \
+    -H "Accept: application/vnd.github.v3+json" \
+    repos/kilork/keycloak/milestones?state=all \
+    --jq '.[].title' `
+  echo "output: $output"
+}
+
+if [ "${LAST_KEYCLOAK_VERSION}" != "${KEYCLOAK_VERSION}" ]; then
+  echo "version of keycloak (${LAST_KEYCLOAK_VERSION}) is different to project version (${KEYCLOAK_VERSION})"
+  BRANCH=$(git branch --show-current)
+  DEF_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+  if [ "${BRANCH}" != "${DEF_BRANCH}" ]; then
+    last_keycloak_major_version=$(echo ${LAST_KEYCLOAK_VERSION} | cut -f 1,2 -d".")
+    last_keycloak_minor_version=$(echo $(($(echo ${LAST_KEYCLOAK_VERSION} | cut -f 3 -d".") * 100)))
+    MILESTONE=${last_keycloak_major_version}.${last_keycloak_minor_version}
+    echo target milestone: $MILESTONE
+    get_milestone $MILESTONE
+    exit 1
+  else
+    echo "no actions would be performed in non-default branch, running regular update"
+  fi
+fi
+
+GITHUB_ISSUE=$(git branch --show-current | grep -oh "^\d*")
 
 echo "Enter cargo version [${KEYCLOAK_RUST_VERSION}]: \c"
 read keycloak_rust_version
@@ -24,10 +57,10 @@ echo "cargo version: ${KEYCLOAK_RUST_VERSION} rest: ${KEYCLOAK_VERSION} issue: $
 echo "Continue [Y]? \c"
 read CONFIRM
 case "$CONFIRM" in
-  [Nn]*)
-    exit 0
-    ;;
-  *)
+[Nn]*)
+  exit 0
+  ;;
+*) ;;
 esac
 
 KEYCLOAK_REST_DOCS=https://www.keycloak.org/docs-api/${KEYCLOAK_VERSION}/rest-api/index.html
@@ -35,12 +68,12 @@ echo "Download and update docs from ${KEYCLOAK_REST_DOCS} [Y]? \c"
 read CONFIRM
 
 case "$CONFIRM" in
-  [Yy]*|"")
-    curl ${KEYCLOAK_REST_DOCS} -o docs/rest-api.html
-    git diff docs/rest-api.html || true
-    echo "Docs updated."
-    ;;
-  *) echo "No docs updated."
+[Yy]* | "")
+  curl ${KEYCLOAK_REST_DOCS} -o docs/rest-api.html
+  git diff docs/rest-api.html || true
+  echo "Docs updated."
+  ;;
+*) echo "No docs updated." ;;
 esac
 
 echo Updating documentation...
@@ -51,16 +84,16 @@ git diff README.md || true
 echo "Continue [Y]? \c"
 read CONFIRM
 case "$CONFIRM" in
-  [Nn]*)
-    exit 0
-    ;;
-  *)
+[Nn]*)
+  exit 0
+  ;;
+*) ;;
 esac
 
 echo Generating types...
 git checkout -- src/types.rs src/rest/generated_rest.rs
-cargo run --example gen -- types > src/types2.rs
-cargo run --example gen -- rest > src/rest/rest2.rs
+cargo run --example gen -- types >src/types2.rs
+cargo run --example gen -- rest >src/rest/rest2.rs
 mv src/types2.rs src/types.rs
 mv src/rest/rest2.rs src/rest/generated_rest.rs
 echo Types generated.
@@ -74,10 +107,10 @@ git diff || true
 echo "Commit changes to git [Y]? \c"
 read CONFIRM
 case "$CONFIRM" in
-  [Nn]*)
-    exit 0
-    ;;
-  *)
+[Nn]*)
+  exit 0
+  ;;
+*) ;;
 esac
 
 git add .
@@ -90,10 +123,10 @@ git tag --list -n10 v${KEYCLOAK_RUST_VERSION}
 echo "Publish to crates.io [Y]? \c"
 read CONFIRM
 case "$CONFIRM" in
-  [Nn]*)
-    exit 0
-    ;;
-  *)
+[Nn]*)
+  exit 0
+  ;;
+*) ;;
 esac
 
 cargo publish

--- a/update.ts
+++ b/update.ts
@@ -1,6 +1,6 @@
-import * as log from "https://deno.land/std@0.213.0/log/mod.ts";
-import * as toml from "https://deno.land/std@0.213.0/toml/mod.ts";
-import * as semver from "https://deno.land/std@0.213.0/semver/mod.ts";
+import * as log from "https://deno.land/std@0.214.0/log/mod.ts";
+import * as toml from "https://deno.land/std@0.214.0/toml/mod.ts";
+import * as semver from "https://deno.land/std@0.214.0/semver/mod.ts";
 
 import {
   Checkbox,
@@ -650,7 +650,6 @@ class Updater {
           const pullRequest =
             (await this.git.pullRequests(`head:${currentBranch}`)).pop();
           if (pullRequest !== undefined) {
-            
           }
         }
       }
@@ -752,7 +751,7 @@ async function main(_args: string[]) {
 
 main(Deno.args);
 
-import { assertEquals } from "https://deno.land/std@0.213.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.214.0/assert/mod.ts";
 
 Deno.test("detectExistingIssue", () => {
   assertEquals(

--- a/update.ts
+++ b/update.ts
@@ -1,0 +1,562 @@
+import * as log from "https://deno.land/std@0.197.0/log/mod.ts";
+import * as toml from "https://deno.land/std@0.197.0/toml/mod.ts";
+import * as semver from "https://deno.land/std@0.197.0/semver/mod.ts";
+
+import {
+  Checkbox,
+  Confirm,
+  prompt,
+  Select,
+} from "https://deno.land/x/cliffy@v1.0.0-rc.2/prompt/mod.ts";
+
+class HttpError extends Error {
+  readonly body?: string;
+
+  constructor(message: string, body?: string) {
+    super(message);
+    this.body = body;
+    Object.setPrototypeOf(this, HttpError.prototype);
+  }
+}
+
+class CommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, CommandError.prototype);
+  }
+}
+
+async function responseBody(response: Response): Promise<string> {
+  if (!response.ok) {
+    const message = `${response.status} ${response.statusText}`;
+    let body;
+
+    if (response.bodyUsed) {
+      body = await response.text();
+    }
+
+    throw new HttpError(message, body);
+  }
+  return await response.text();
+}
+
+class Keycloak {
+  async latestVersion(): Promise<Version> {
+    const response = await fetch("https://keycloak.org");
+    const body = await responseBody(response);
+
+    return new Version((/Latest release (.+)\s/.exec(body) ?? [])[1]);
+  }
+
+  apiUrl(version: Version): string {
+    return `https://www.keycloak.org/docs-api/${version}/rest-api/index.html`;
+  }
+
+  async apiDocs(version: Version): Promise<string> {
+    const response = await fetch(this.apiUrl(version));
+    return await responseBody(response);
+  }
+}
+
+class Cargo {
+  get text(): string {
+    return Deno.readTextFileSync("Cargo.toml");
+  }
+
+  set text(value) {
+    Deno.writeTextFileSync("Cargo.toml", value);
+  }
+
+  get version(): InternalVersion {
+    const cargoToml = toml.parse(this.text);
+
+    interface Package {
+      readonly version: string;
+    }
+
+    return new InternalVersion(
+      (cargoToml.package as Package).version,
+    );
+  }
+
+  set version(value: InternalVersion) {
+    const lines = this.text.split("\n");
+    const index = lines.findIndex((line) => line.startsWith("version = "));
+    if (index !== -1) {
+      lines[index] = `version = "${value}"`;
+      this.text = lines.join("\n");
+    }
+  }
+}
+
+class Branch {
+  readonly value: string;
+
+  constructor(value: string) {
+    this.value = value.trim();
+  }
+
+  toString() {
+    return this.value;
+  }
+}
+
+interface Issue {
+  milestone?: string;
+  number: number;
+  title: string;
+}
+
+interface Milestone {
+  number: number;
+  title: string;
+}
+
+class User {
+  autoconfirm: boolean;
+
+  constructor(autoconfirm: boolean = false) {
+    this.autoconfirm = autoconfirm;
+  }
+
+  async confirm(message: string): Promise<boolean> {
+    if (this.autoconfirm) {
+      return true;
+    }
+
+    return await Confirm.prompt(message);
+  }
+
+  async selectUpdateOptions(
+    updater: Updater,
+  ) {
+    const { options } = updater;
+    const { versions } = options;
+    const latestVersion = versions.keycloakLatestVersion?.toInternalVersion();
+    const cargoVersion = versions.keycloakCargoVersion;
+    const result = await prompt([
+      {
+        name: "baseVersion",
+        message: "Select which version to use for update",
+        type: Select,
+        options: [
+          {
+            name: `Latest Keycloak version: ${latestVersion}`,
+            value: "latest",
+          },
+          {
+            name: `Cargo.toml version: ${cargoVersion}`,
+            value: "cargo",
+          },
+          ...versions.currentMilestones!.map((milestone) => ({
+            name: `Milestone ${milestone.title}`,
+            value: milestone.title,
+          })),
+          ...[
+            {
+              name: `Enter manually`,
+              value: "manual",
+            },
+          ],
+        ],
+        after: async ({ baseVersion }, next) => {
+          let milestoneVersion;
+          switch (baseVersion) {
+            case "latest":
+              milestoneVersion = latestVersion;
+              break;
+            case "cargo":
+              milestoneVersion = cargoVersion;
+              break;
+            default:
+              milestoneVersion = new InternalVersion(baseVersion!);
+              break;
+          }
+          options.milestoneVersion = milestoneVersion;
+          const milestone = await updater.git.milestone(
+            milestoneVersion!.toString(),
+          );
+          if (!milestone) {
+            await next("createMilestone");
+          } else {
+            versions.milestone = milestone;
+            await next("createReleaseIssue");
+          }
+        },
+      },
+      {
+        name: "createMilestone",
+        message: `Milestone does not exist. Should we create it?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "createReleaseIssue",
+        message: `Create release issue?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "createReleasePullRequest",
+        message: `Create release pull request?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "assignMilestone",
+        message: `Assign milestone to issues and merge requests?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "changeCargoTomlVersion",
+        message: `Change Cargo.toml version?`,
+        type: Confirm,
+        default: true,
+        before: async ({ baseVersion }, next) => {
+          if (baseVersion === "cargo") {
+            await next("downloadApiDocs");
+          } else {
+            await next();
+          }
+        },
+      },
+      {
+        name: "downloadApiDocs",
+        message: `Download API documentation?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "downloadApiDocs",
+        message: `Run generator?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "gitCommit",
+        message: `Create commit in Git?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "gitTag",
+        message: `Create tag in Git?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "gitPush",
+        message: `Push changes to GitHub?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "gitRelease",
+        message: `Create release on GitHub?`,
+        type: Confirm,
+        default: true,
+      },
+      {
+        name: "cratesPublish",
+        message: `Publish release on crates.io?`,
+        type: Confirm,
+        default: true,
+      },
+    ]);
+
+    return result as Required<typeof result>;
+  }
+
+  async selectIssuesAndPullRequests(issues: Issue[]): Promise<Issue[]> {
+    return (await Checkbox.prompt({
+      message: "Select issues to assign milestone",
+      options: [{
+        name: "Issues",
+        options: issues.map((issue) => ({ name: issue.title, value: issue })),
+      }],
+    })).map((option) => (option.value));
+  }
+}
+
+class Command {
+  static async execute(cmd: string, args: string[]): Promise<string> {
+    const command = new Deno.Command(cmd, {
+      args,
+      stdout: "piped",
+    });
+
+    const { code, stdout, stderr } = await command.output();
+    if (code !== 0) {
+      throw new CommandError(new TextDecoder().decode(stderr));
+    }
+    return new TextDecoder().decode(stdout);
+  }
+}
+
+class Git {
+  private readonly repository;
+
+  constructor(repository: string) {
+    this.repository = repository;
+  }
+
+  async currentBranch(): Promise<Branch> {
+    return new Branch(
+      await this.gitCommand([
+        "branch",
+        "--show-current",
+      ]),
+    );
+  }
+
+  async defaultBranch(): Promise<Branch> {
+    const prefix = "refs/remotes/origin/";
+    const refs = await this.gitCommand([
+      "symbolic-ref",
+      `${prefix}HEAD`,
+    ]);
+    if (refs.startsWith(prefix)) {
+      return new Branch(refs.substring(prefix.length));
+    } else {
+      throw new CommandError(
+        `could not determine default branch, output: ${refs}`,
+      );
+    }
+  }
+
+  async issue(number: string): Promise<Issue> {
+    return await this.ghCommandJson([
+      "issue",
+      "view",
+      number,
+      "--json",
+      "number,milestone,title",
+    ]);
+  }
+
+  async issues(): Promise<Issue[]> {
+    return await this.ghCommandJson([
+      "issue",
+      "list",
+      "--json",
+      "number,milestone,title",
+    ]);
+  }
+
+  async milestone(title: string): Promise<Milestone | undefined> {
+    return (await this.milestones("all")).find((m) => m.title === title);
+  }
+
+  async milestones(state: "all" | "open"): Promise<[Milestone]> {
+    return await this.ghCommandJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github.v3+json",
+      `/repos/${this.repository}/milestones?state=${state}`,
+    ]);
+  }
+
+  async createMilestone(version: InternalVersion) {
+    const result = await this.ghCommand([
+      "api",
+      "--method",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github.v3+json",
+      `/repos/${this.repository}/milestones`,
+      "-f",
+      `title=${version}`,
+      "-f",
+      "state=open",
+    ]);
+    console.log(result);
+  }
+
+  private async gitCommand(args: string[]): Promise<string> {
+    return await Command.execute("git", args);
+  }
+
+  private async ghCommand(args: string[]): Promise<string> {
+    return await Command.execute("gh", args);
+  }
+
+  private async ghCommandJson<T>(args: string[]): Promise<T> {
+    return JSON.parse(await this.ghCommand(args));
+  }
+}
+
+class Version {
+  readonly asString: string;
+  readonly value: semver.SemVer;
+
+  constructor(str: string) {
+    this.asString = str;
+    this.value = semver.parse(str);
+  }
+
+  toString() {
+    return this.asString;
+  }
+
+  toInternalVersion(): InternalVersion {
+    const {
+      major,
+      minor,
+      patch,
+    } = this.value;
+    return new InternalVersion(`${major}.${minor}.${Math.round(patch * 100)}`);
+  }
+}
+
+class InternalVersion {
+  private version: Version;
+  constructor(str: string) {
+    this.version = new Version(str);
+  }
+
+  toString() {
+    return this.version.toString();
+  }
+
+  toVersion(): Version {
+    const {
+      major,
+      minor,
+      patch,
+    } = this.version.value;
+    return new Version(`${major}.${minor}.${Math.round(patch / 100)}`);
+  }
+}
+
+class Options {
+  milestoneVersion?: InternalVersion;
+  versions: Partial<Versions> = {};
+
+  toString(): string {
+    return JSON.stringify(this, null, 2);
+  }
+}
+
+interface Versions {
+  milestone: Milestone | string;
+  pr: string;
+  issue: Issue;
+
+  currentBranch: Branch;
+  defaultBranch: Branch;
+  currentMilestones: [Milestone];
+
+  keycloakLatestVersion: Version;
+  keycloakCargoVersion: InternalVersion;
+}
+
+class Updater {
+  readonly cargo: Cargo = new Cargo();
+  readonly git: Git = new Git("kilork/keycloak");
+  readonly keycloak: Keycloak = new Keycloak();
+  readonly user: User = new User();
+
+  options: Options = new Options();
+
+  async run() {
+    const versions = {
+      keycloakLatestVersion: await this.keycloak.latestVersion(),
+      keycloakCargoVersion: this.cargo.version,
+      currentBranch: await this.git.currentBranch(),
+      defaultBranch: await this.git.defaultBranch(),
+      currentMilestones: await this.git.milestones("open"),
+    };
+
+    this.options.versions = versions;
+
+    // const { currentBranch, defaultBranch } = versions;
+
+    const keycloakApiDocs = await this.keycloak.apiDocs(
+      versions.keycloakLatestVersion,
+    );
+
+    const options = await this.user.selectUpdateOptions(this);
+
+    const milestoneVersion = this.options.milestoneVersion!;
+
+    if (options.createMilestone) {
+      this.info(`Creating milestone ${milestoneVersion}...`);
+      await this.git.createMilestone(milestoneVersion);
+    }
+
+    if (options.baseVersion !== "cargo" && options.changeCargoTomlVersion) {
+      this.info(`Changing Cargo.toml version to ${milestoneVersion}...`);
+      this.cargo.version = milestoneVersion;
+    }
+
+    if (options.assignMilestone) {
+      const issues = await this.git.issues();
+      console.log(issues);
+      const selectedIssues = await this.user.selectIssuesAndPullRequests(
+        issues,
+      );
+    }
+
+    // this.info(`${this.options}`);
+
+    // this.info(keycloakApiDocs);
+  }
+
+  async optionsToCreate() {
+    await this.prepareCreateMilestone();
+  }
+
+  async optionsForExisting() {
+    await this.detectExistingIssue();
+  }
+
+  async detectExistingIssue() {
+    const { currentBranch } = this.options.versions;
+    const number = detectExistingIssue(
+      currentBranch!.toString(),
+    );
+    if (number) {
+      const issue = await this.git.issue(number);
+      this.options.versions.issue = issue;
+      if (issue.milestone) {
+        this.options.versions.milestone = await this.git.milestone(
+          issue.milestone!,
+        );
+      } else {
+        this.prepareCreateMilestone();
+      }
+    }
+  }
+
+  prepareCreateMilestone() {
+    const { keycloakLatestVersion } = this.options.versions;
+    const milestone = keycloakLatestVersion?.toInternalVersion();
+    this.options.versions.milestone = milestone?.toString();
+  }
+
+  info(message: string) {
+    log.info(message);
+  }
+}
+
+function detectExistingIssue(currentBranch: string): string | undefined {
+  return currentBranch.toString().match(/^\d+/)?.pop();
+}
+
+async function main(_args: string[]) {
+  await new Updater().run();
+}
+
+main(Deno.args);
+
+import { assertEquals } from "https://deno.land/std@0.197.0/assert/mod.ts";
+import { join } from "https://deno.land/std@0.192.0/path/win32.ts";
+
+Deno.test("detectExistingIssue", () => {
+  assertEquals(
+    detectExistingIssue("62-allow-release"),
+    "62",
+    "cannot detect existing issue from branch",
+  );
+});

--- a/update.ts
+++ b/update.ts
@@ -289,6 +289,12 @@ class User {
         default: true,
       },
       {
+        name: "updateDocs",
+        message: `Update documentation?`,
+        type: Confirm,
+        default: true,
+      },
+      {
         name: "runGenerator",
         message: `Run generator?`,
         type: Confirm,
@@ -725,6 +731,9 @@ class Updater {
     if (options.downloadApiDocs) {
       const apiDocs = await this.keycloak.apiDocs(milestoneVersion.toVersion());
       Deno.writeTextFileSync("docs/rest-api.html", apiDocs);
+    }
+
+    if (options.updateDocs) {
       await Command.spawn("handlebars-magic", ["templates", "."]);
     }
 
@@ -759,7 +768,7 @@ class Updater {
         await this.git.developIssue(issue);
       }
     }
-    // TODO: Create release issue?
+
     // TODO: Create commit in Git?
     // TODO: Create tag in Git?
     // TODO: Push changes to GitHub?

--- a/update.ts
+++ b/update.ts
@@ -725,6 +725,7 @@ class Updater {
     if (options.downloadApiDocs) {
       const apiDocs = await this.keycloak.apiDocs(milestoneVersion.toVersion());
       Deno.writeTextFileSync("docs/rest-api.html", apiDocs);
+      await Command.spawn("handlebars-magic", ["templates", "."]);
     }
 
     if (options.runGenerator) {
@@ -751,13 +752,6 @@ class Updater {
       await this.cargo.build();
     }
 
-    // TODO: Create release issue?
-    // TODO: Create commit in Git?
-    // TODO: Create tag in Git?
-    // TODO: Push changes to GitHub?
-    // TODO: Create release pull request?
-    // TODO: Create release on GitHub?
-    // TODO: Publish release on crates.io?
     if (options.createReleaseIssue && milestoneExists) {
       const issue = await this.createReleaseIssue(milestoneVersion);
       this.options.versions.issue = issue;
@@ -765,6 +759,13 @@ class Updater {
         await this.git.developIssue(issue);
       }
     }
+    // TODO: Create release issue?
+    // TODO: Create commit in Git?
+    // TODO: Create tag in Git?
+    // TODO: Push changes to GitHub?
+    // TODO: Create release pull request?
+    // TODO: Create release on GitHub?
+    // TODO: Publish release on crates.io?
 
     if (options.createReleasePullRequest) {
       const issueExists = this.options.versions.issue !== undefined;

--- a/update.ts
+++ b/update.ts
@@ -236,6 +236,13 @@ class User {
         message: `Assign milestone to issues and merge requests?`,
         type: Confirm,
         default: true,
+        before: async ({ createMilestone }, next) => {
+          if (!(createMilestone ?? true)) {
+            await next("changeCargoTomlVersion");
+          } else {
+            await next();
+          }
+        }
       },
       {
         name: "changeCargoTomlVersion",


### PR DESCRIPTION
- use deno script for updates
- input milestone
- select pull requests
- do not assign milestone if it does not exist
- assign issues and pull requests to milestone
- move issue creation at the end of update
- update deps
- download docs and run generator
- added handlebar-magic call
- separated update docs
- closed todos
