### PR TITLE
acquire fn public in admin token retriever

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -63,7 +63,7 @@ impl KeycloakServiceAccountAdminTokenRetriever {
         }
     }
 
-    async fn acquire(&self, url: &str) -> Result<KeycloakAdminToken, KeycloakError> {
+    pub async fn acquire(&self, url: &str) -> Result<KeycloakAdminToken, KeycloakError> {
         let realm = &self.realm;
         let response = self
             .reqwest_client


### PR DESCRIPTION
We need to get the admin token for service accounts.

as developer i would like to do: 

```rust
let retriever = KeycloakServiceAccountAdminTokenRetriever::create(
    client_id,
    client_secret,
    realm,
    client,
};
let admin_token = retriever.acquire(&url).await;
```