### PR TITLE
updated body parameter's type to Value in partial import

### DIFF
--- a/examples/openapi.patch.toml
+++ b/examples/openapi.patch.toml
@@ -1,6 +1,9 @@
 [path."/admin/realms:post:body"]
 from_type = "String"
 rust_type = "RealmRepresentation"
+[path."/admin/realms/{realm}/partialImport:post:body"]
+from_type = "String"
+rust_type = "RealmRepresentation"
 [path."/admin/realms/{realm}/authentication/register-required-action:post:body"]
 from_type = "TypeMap<String, String>"
 rust_type = "RequiredActionProviderRepresentation"

--- a/src/rest/generated_rest.rs
+++ b/src/rest/generated_rest.rs
@@ -7719,7 +7719,7 @@ impl<TS: KeycloakTokenSupplier> KeycloakAdmin<TS> {
     pub async fn realm_partial_import_post(
         &self,
         realm: &str,
-        body: Value,
+        body: RealmRepresentation,
     ) -> Result<Value, KeycloakError> {
         let realm = p(realm);
         let builder = self

--- a/src/rest/generated_rest.rs
+++ b/src/rest/generated_rest.rs
@@ -7719,7 +7719,7 @@ impl<TS: KeycloakTokenSupplier> KeycloakAdmin<TS> {
     pub async fn realm_partial_import_post(
         &self,
         realm: &str,
-        body: String,
+        body: Value,
     ) -> Result<Value, KeycloakError> {
         let realm = p(realm);
         let builder = self


### PR DESCRIPTION
Problem: Reqwest will always put double quotes in the `body` if you take it as `String` and entire JSON will be marked as invalid by keycloak API.

Solution: Use `Value` provided by serde to send JSON.