### PR TITLE
reduce `serde_with` dependencies which are unused by `keycloak`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,28 @@ rc-map = ["serde/rc"]
 rc-str = ["serde/rc"]
 rc-val = ["serde/rc"]
 rc-vec = ["serde/rc"]
-tags-all = ["tag-attack-detection", "tag-authentication-management", "tag-client-attribute-certificate", "tag-client-initial-access", "tag-client-registration-policy", "tag-client-role-mappings", "tag-client-scopes", "tag-clients", "tag-component", "tag-groups", "tag-identity-providers", "tag-key", "tag-organizations", "tag-protocol-mappers", "tag-realms-admin", "tag-role-mapper", "tag-roles", "tag-roles-by-id", "tag-scope-mappings", "tag-users"]
+tags-all = [
+    "tag-attack-detection",
+    "tag-authentication-management",
+    "tag-client-attribute-certificate",
+    "tag-client-initial-access",
+    "tag-client-registration-policy",
+    "tag-client-role-mappings",
+    "tag-client-scopes",
+    "tag-clients",
+    "tag-component",
+    "tag-groups",
+    "tag-identity-providers",
+    "tag-key",
+    "tag-organizations",
+    "tag-protocol-mappers",
+    "tag-realms-admin",
+    "tag-role-mapper",
+    "tag-roles",
+    "tag-roles-by-id",
+    "tag-scope-mappings",
+    "tag-users",
+]
 tag-attack-detection = []
 tag-authentication-management = []
 tag-client-attribute-certificate = []
@@ -48,7 +69,7 @@ tag-users = []
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-serde_with = "3"
+serde_with = { version = "3", default-features = false, features = ["macros"] }
 async-trait = "0.1"
 schemars = { version = "0.8.11", default-features = false, features = [
     "derive",


### PR DESCRIPTION
by default serde_with comes with "std" which itself includes many dependencies like multiple version of indexmap and schemars. As its not needed, disable those dependencies