### PR TITLE
fix: add missing None arguments to realm_users_get call

### DIFF
--- a/examples/adduser.rs
+++ b/examples/adduser.rs
@@ -54,6 +54,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             None,
             None,
             None,
+            None,
+            None,
             Some("user".into()),
         )
         .await?;

--- a/update.ts
+++ b/update.ts
@@ -98,7 +98,7 @@ class Cargo {
   }
 
   async build() {
-    return await this.cargoCommandSpawn(["build"]);
+    return await this.cargoCommandSpawn(["build", "--examples"]);
   }
 
   async publish() {


### PR DESCRIPTION
The example was failing to compile because realm_users_get expects 17 parameters but only 15 were provided. This adds 2 more None arguments to match the expected function signature.