### PR TITLE
fix: make attribute values optional

### DIFF
--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -1236,7 +1236,7 @@ pub enum {name} {{
                         unique_items: _,
                     } => {
                         let item_type = if let Some(items) = items {
-                            items.to_rust_type(RefMode::Std)
+                            items.to_rust_type_opt(RefMode::Std)
                         } else {
                             "TypeValue".into()
                         };


### PR DESCRIPTION
While using this package, I came across a bug with this struct because I have an attribute on my users that can be null, so it was crashing due to that when fetching the users. I found a workaround which was to enable brief_representation but this should fix the issue natively