### PR TITLE
fix: update schemars to 1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/kilork/keycloak"
 keywords = ["api", "async", "keycloak", "rest"]
 license = "Unlicense OR MIT"
 repository = "https://github.com/kilork/keycloak"
-rust-version = "1.87"
+rust-version = "1.88"
 
 [features]
 default = ["tags-all", "resource-builder", "reqwest"]
@@ -65,7 +65,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 async-trait = "0.1"
-schemars = { version = "0.8.22", optional = true, default-features = false, features = [ "derive" ] }
+schemars = { version = "1.2.1", optional = true, default-features = false, features = [ "derive", "std" ] }
 percent-encoding = "2.3.2"
 
 [dev-dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87"
+channel = "1.88"
 profile = "minimal"
 components = [ "rustfmt", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
required updates:
- minimum rustc version to 1.88 (from 1.87)
- added feature `std` to schemars (required for derived schema on e.g. `HashMap`s)