### PR TITLE
Expose KeycloakAdminToken fields via accessor methods

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -101,6 +101,49 @@ pub struct KeycloakAdminToken {
     token_type: String,
 }
 
+impl KeycloakAdminToken {
+    /// Returns the access token issued by Keycloak.
+    pub fn access_token(&self) -> &str {
+        &self.access_token
+    }
+
+    /// Returns the lifetime in seconds of the access token.
+    pub fn expires_in(&self) -> usize {
+        self.expires_in
+    }
+
+    /// Returns the `not-before-policy` value, if provided by Keycloak.
+    pub fn not_before_policy(&self) -> Option<usize> {
+        self.not_before_policy
+    }
+
+    /// Returns the lifetime in seconds of the refresh token, if a refresh
+    /// token was issued.
+    pub fn refresh_expires_in(&self) -> Option<usize> {
+        self.refresh_expires_in
+    }
+
+    /// Returns the refresh token, if one was issued.
+    pub fn refresh_token(&self) -> Option<&str> {
+        self.refresh_token.as_deref()
+    }
+
+    /// Returns the OAuth scope(s) associated with the token.
+    pub fn scope(&self) -> &str {
+        &self.scope
+    }
+
+    /// Returns the session state, if provided by Keycloak.
+    pub fn session_state(&self) -> Option<&str> {
+        self.session_state.as_deref()
+    }
+
+    /// Returns the token type (typically `Bearer`).
+    pub fn token_type(&self) -> &str {
+        &self.token_type
+    }
+}
+
 #[async_trait]
 impl KeycloakTokenSupplier for KeycloakAdminToken {
     async fn get(&self, _url: &str) -> Result<String, KeycloakError> {


### PR DESCRIPTION
Closes #188

Adds public accessor methods for all fields on `KeycloakAdminToken` so users can build custom token suppliers (e.g. cached with TTL based on `expires_in`) without having to deserialize into `serde_json::Value`.

* `Copy` types (`usize`, `Option<usize>`) are returned by value.
* `String` fields are returned as `&str` / `Option<&str>` without allocation.
* Field types themselves are unchanged, preserving serde behaviour and avoiding any breaking change to the on-the-wire format.

```rust
let token = KeycloakAdminToken::acquire(...).await?;
let ttl = token.expires_in();           // usize
let refresh = token.refresh_token();    // Option<&str>
```