### PR TITLE
ci: bump rust-toolchain to 1.88.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.87.0
+    - uses: dtolnay/rust-toolchain@1.88.0
     - run: mkdir .cargo && cp .cargo-config.toml .cargo/config.toml
     - name: Build with default features
       run: cargo build


### PR DESCRIPTION
Companion to #191.

That PR raises the MSRV from 1.87 to 1.88 in `Cargo.toml` and `rust-toolchain.toml`, but leaves the GitHub Actions workflow pinned to `dtolnay/rust-toolchain@1.87.0`. Once #191 lands, CI will fail trying to build a crate that now requires Rust 1.88.

This PR bumps the workflow to `1.88.0`, aligning CI with the new MSRV.